### PR TITLE
Add erlzk to the applications list

### DIFF
--- a/src/riak_mesos_md_mgr.app.src
+++ b/src/riak_mesos_md_mgr.app.src
@@ -5,7 +5,8 @@
   {registered, []},
   {applications, [
                   kernel,
-                  stdlib
+                  stdlib,
+                  erlzk
                  ]},
   {mod, { riak_mesos_md_mgr_app, []}},
   {env, []}


### PR DESCRIPTION
Without this application:ensure_all_started(riak_mesos_md_mgr) doesn't work